### PR TITLE
feat: Arena V2 mobile optimization - responsive layout and compact UI

### DIFF
--- a/ARENA_V2_TCG_CARDS_ADDED.md
+++ b/ARENA_V2_TCG_CARDS_ADDED.md
@@ -1,0 +1,121 @@
+# Arena V2 - TCG Cards Implementation
+
+## Summary
+Added Holobot TCG (Trading Card Game) cards to Arena V2, similar to the display in Arena V1. Now both player and opponent Holobots are displayed as TCG cards during battles.
+
+## Changes Made
+
+### 1. Updated `FighterDisplay` Component
+**File**: `src/components/arena/FighterDisplay.tsx`
+
+- Added import for `HolobotCard` component and `HolobotStats` type
+- Created conversion logic to transform `ArenaFighter` data into `HolobotStats` format for TCG card display
+- Integrated TCG card display into the fighter display layout
+- Cards are scaled to 75% (`scale-75`) to fit appropriately in the battle UI
+- Player's card displays with blue variant (bottom position)
+- Opponent's card displays with red variant (top position)
+
+**Key Features:**
+- TCG cards show next to the fighter avatar
+- Cards display all relevant stats: HP, Attack, Defense, Speed
+- Special move and ability description are shown on the card
+- Cards maintain the same visual style as Arena V1
+
+### 2. Updated `ArenaFighter` Type
+**File**: `src/types/arena.ts`
+
+Added optional fields to support TCG card display:
+```typescript
+// Optional TCG Card Display Fields
+specialMove?: string;
+abilityDescription?: string;
+```
+
+These fields allow fighters to include specific ability information that displays on their TCG cards.
+
+### 3. Updated Fighter Initialization
+**File**: `src/pages/Index.tsx`
+
+Modified both player and opponent fighter initialization in the `ArenaV2Wrapper` component:
+
+**Player Fighter:**
+- Added `specialMove` from `userHolobotStats.specialMove`
+- Added `abilityDescription` from `userHolobotStats.abilityDescription`
+- Falls back to defaults if stats are unavailable
+
+**Opponent Fighter:**
+- Added `specialMove` from `opponentBaseStats.specialMove`
+- Added `abilityDescription` from `opponentBaseStats.abilityDescription`
+- Falls back to defaults if stats are unavailable
+
+## Visual Layout
+
+```
+┌──────────────────────────────────────────────────────┐
+│  HOLOBOTS ARENA V2                                   │
+│  Round 1/3 • Wins: 0                                 │
+├──────────────────────────────────────────────────────┤
+│  Opponent Section (Top)                              │
+│  ┌──────────┐  ┌────────┐  ┌──────────────┐        │
+│  │ TCG Card │  │ Avatar │  │ HP/Stats Bar │        │
+│  │  (Red)   │  │  Image │  │              │        │
+│  └──────────┘  └────────┘  └──────────────┘        │
+├──────────────────────────────────────────────────────┤
+│  Battlefield Center                                  │
+├──────────────────────────────────────────────────────┤
+│  Player Section (Bottom)                             │
+│  ┌──────────────┐  ┌────────┐  ┌──────────┐        │
+│  │ HP/Stats Bar │  │ Avatar │  │ TCG Card │        │
+│  │              │  │  Image │  │  (Blue)  │        │
+│  └──────────────┘  └────────┘  └──────────┘        │
+│                                                      │
+│  [Action Cards Hand]                                 │
+│  [Battle Controls]                                   │
+└──────────────────────────────────────────────────────┘
+```
+
+## TCG Card Display Features
+
+Each TCG card shows:
+1. **Header**: HOLOBOTS branding + Holobot name + Level
+2. **Image**: Pixelated Holobot sprite
+3. **Ability Section**: Special move name and description
+4. **Stats**: HP, Attack, Defense, Speed in compact format
+5. **Footer**: Level and Rank display
+6. **Color Coding**:
+   - Blue border for player (bottom)
+   - Red border for opponent (top)
+   - Rank-based colors for owned Holobots
+
+## Benefits
+
+1. **Visual Consistency**: Matches the TCG card style from Arena V1
+2. **Enhanced Information**: Players can see detailed stats and abilities at a glance
+3. **Improved UX**: Clear visual distinction between player and opponent
+4. **Maintains Style**: Uses the same `HolobotCard` component throughout the app
+
+## Testing
+
+The changes have been implemented and hot-reloaded in the development server. To test:
+
+1. Navigate to the Arena section
+2. Select Arena V2
+3. Choose a Holobot and enter battle
+4. Observe TCG cards displayed for both player (bottom, blue) and opponent (top, red)
+
+## Related Files
+
+- `src/components/HolobotCard.tsx` - The reusable TCG card component
+- `src/components/arena/FighterDisplay.tsx` - Fighter display with TCG cards
+- `src/types/arena.ts` - ArenaFighter type definition
+- `src/pages/Index.tsx` - Arena V2 battle initialization
+- `src/components/arena/BattleArenaView.tsx` - Main battle view component
+
+## Future Enhancements
+
+Potential improvements:
+1. Add animation effects when cards take damage
+2. Show special move activation visually on the card
+3. Add glow effects based on fighter status (defending, combo, etc.)
+4. Scale adjustment based on screen size for mobile optimization
+5. Add card flip animation on fighter switch between rounds

--- a/src/components/HolobotCard.tsx
+++ b/src/components/HolobotCard.tsx
@@ -25,9 +25,9 @@ export const HolobotCard = ({
   console.log(`Rendering HolobotCard for ${holobotName} with image path: ${imagePath}`);
   
   return (
-    <div className={`w-[130px] md:w-[180px] h-auto rounded-lg ${
+    <div className={`w-[100px] sm:w-[130px] md:w-[180px] h-auto rounded-lg ${
       variant === "red" ? "bg-red-900/80 border-red-400" : rankColor
-    } border-2 p-1.5 flex flex-col font-mono text-[8px] transition-all duration-300 hover:scale-105 shadow-lg`}>
+    } border-2 p-1 sm:p-1.5 flex flex-col font-mono text-[7px] sm:text-[8px] transition-all duration-300 hover:scale-105 shadow-lg`}>
       <div className="flex items-center justify-between mb-1 bg-black/40 px-1.5 py-0.5 rounded-md border border-white/20">
         <span className="font-bold italic text-white drop-shadow-[0_1px_1px_rgba(0,0,0,0.8)]">
           HOLOBOTS

--- a/src/components/arena/ActionCardComponent.tsx
+++ b/src/components/arena/ActionCardComponent.tsx
@@ -44,7 +44,7 @@ export function ActionCardComponent({ card, onPlay, disabled = false }: ActionCa
       onMouseLeave={() => setIsHovered(false)}
       disabled={!canPlay}
       className={`
-        relative w-28 h-40 rounded-lg p-2 shrink-0
+        relative w-20 h-28 sm:w-24 sm:h-36 md:w-28 md:h-40 rounded-lg p-1.5 sm:p-2 shrink-0
         flex flex-col items-center justify-between
         border-2 transition-all duration-200
         ${getCardTypeColor(card.type)}
@@ -56,13 +56,13 @@ export function ActionCardComponent({ card, onPlay, disabled = false }: ActionCa
       `}
     >
       {/* Card Type Badge */}
-      <div className="absolute -top-2 left-1/2 -translate-x-1/2 bg-black/70 text-white text-xs px-2 py-0.5 rounded-full uppercase">
+      <div className="absolute -top-2 left-1/2 -translate-x-1/2 bg-black/70 text-white text-[8px] sm:text-[10px] md:text-xs px-1.5 sm:px-2 py-0.5 rounded-full uppercase">
         {card.type}
       </div>
 
       {/* Card Icon/Visual */}
-      <div className="w-16 h-16 bg-white/10 rounded-full flex items-center justify-center mt-2">
-        <span className="text-3xl">
+      <div className="w-10 h-10 sm:w-12 sm:h-12 md:w-16 md:h-16 bg-white/10 rounded-full flex items-center justify-center mt-1 sm:mt-2">
+        <span className="text-xl sm:text-2xl md:text-3xl">
           {card.type === 'strike' && '👊'}
           {card.type === 'defense' && '🛡️'}
           {card.type === 'combo' && '⚡'}
@@ -72,18 +72,18 @@ export function ActionCardComponent({ card, onPlay, disabled = false }: ActionCa
       </div>
 
       {/* Card Name */}
-      <span className="text-xs font-bold text-white text-center leading-tight">
+      <span className="text-[9px] sm:text-[10px] md:text-xs font-bold text-white text-center leading-tight">
         {card.name}
       </span>
 
       {/* Stamina Cost */}
-      <div className="absolute top-2 right-2 w-7 h-7 bg-black/80 rounded-full flex items-center justify-center border border-yellow-400">
-        <span className="text-xs text-yellow-400 font-bold">{card.staminaCost}</span>
+      <div className="absolute top-1.5 sm:top-2 right-1.5 sm:right-2 w-5 h-5 sm:w-6 sm:h-6 md:w-7 md:h-7 bg-black/80 rounded-full flex items-center justify-center border border-yellow-400">
+        <span className="text-[9px] sm:text-[10px] md:text-xs text-yellow-400 font-bold">{card.staminaCost}</span>
       </div>
 
       {/* Damage (for strike cards) */}
       {card.baseDamage > 0 && (
-        <div className="absolute bottom-2 left-2 px-2 py-0.5 bg-red-600 rounded text-xs text-white font-bold">
+        <div className="absolute bottom-1.5 sm:bottom-2 left-1.5 sm:left-2 px-1.5 sm:px-2 py-0.5 bg-red-600 rounded text-[9px] sm:text-[10px] md:text-xs text-white font-bold">
           {card.baseDamage}
         </div>
       )}

--- a/src/components/arena/ActionCardHand.tsx
+++ b/src/components/arena/ActionCardHand.tsx
@@ -22,16 +22,16 @@ export function ActionCardHand({ cards, onCardSelect, disabled = false }: Action
   }
 
   return (
-    <div className="bg-slate-800/50 backdrop-blur rounded-lg p-4">
-      <div className="flex items-center justify-between mb-2">
-        <h3 className="text-sm font-bold text-white">YOUR HAND</h3>
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-gray-400">{cards.length} cards</span>
-          <span className="text-xs text-cyan-400">⌨️ S•Strike | D•Defend | C•Combo | F•Finisher</span>
+    <div className="bg-slate-800/50 backdrop-blur rounded-lg p-2 sm:p-3 md:p-4">
+      <div className="flex items-center justify-between mb-1 sm:mb-1.5 md:mb-2">
+        <h3 className="text-xs sm:text-sm font-bold text-white">YOUR HAND</h3>
+        <div className="flex items-center gap-1 sm:gap-2 md:gap-3">
+          <span className="text-[9px] sm:text-[10px] md:text-xs text-gray-400">{cards.length} cards</span>
+          <span className="hidden md:inline-block text-xs text-cyan-400">⌨️ S•Strike | D•Defend | C•Combo | F•Finisher</span>
         </div>
       </div>
 
-      <div className="flex gap-2 overflow-x-auto pb-2">
+      <div className="flex gap-1.5 sm:gap-2 overflow-x-auto pb-1 sm:pb-2">
         {cards.map((card) => (
           <ActionCardComponent
             key={card.id}

--- a/src/components/arena/ArenaPrebattleMenu.tsx
+++ b/src/components/arena/ArenaPrebattleMenu.tsx
@@ -191,16 +191,16 @@ export const ArenaPrebattleMenu = ({
 
   return (
     <Card className="border border-holobots-border bg-[#1A1F2C]">
-      <CardHeader>
-        <CardTitle className="text-center text-2xl text-white font-orbitron italic">Arena Battle</CardTitle>
+      <CardHeader className="py-3 sm:py-4 md:py-6">
+        <CardTitle className="text-center text-lg sm:text-xl md:text-2xl text-white font-orbitron italic">Arena Battle</CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="flex flex-col space-y-6">
+      <CardContent className="p-3 sm:p-4 md:p-6">
+        <div className="flex flex-col space-y-3 sm:space-y-4 md:space-y-6">
           {/* First Row: Holobot Selection */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2 sm:gap-3 md:gap-4">
             {/* User Holobot Selection */}
             <div className="flex flex-col">
-              <h3 className="text-red-400 mb-2 text-center md:text-left font-orbitron italic">Select Your Holobot</h3>
+              <h3 className="text-red-400 mb-1 sm:mb-1.5 md:mb-2 text-center md:text-left font-orbitron italic text-sm sm:text-base">Select Your Holobot</h3>
               <Select value={selectedHolobot || undefined} onValueChange={handleHolobotSelect}>
                 <SelectTrigger className="w-full bg-[#1A1F2C] text-white border-holobots-border">
                   {selectedHolobot ? (
@@ -287,7 +287,7 @@ export const ArenaPrebattleMenu = ({
 
             {/* Opponents Header */}
             <div className="flex flex-col">
-              <h4 className="text-red-400 mb-2 text-center md:text-left font-orbitron italic">Your Opponents</h4>
+              <h4 className="text-red-400 mb-1 sm:mb-1.5 md:mb-2 text-center md:text-left font-orbitron italic text-sm sm:text-base">Your Opponents</h4>
             </div>
           </div>
 
@@ -297,84 +297,84 @@ export const ArenaPrebattleMenu = ({
             <div className="flex-1 flex justify-center">
               {selectedHolobot && (
                 <div className="flex flex-col items-center">
-                  <Avatar className="h-20 w-20 border-4 border-cyan-400 shadow-lg">
+                  <Avatar className="h-12 w-12 sm:h-16 sm:w-16 md:h-20 md:w-20 border-2 sm:border-3 md:border-4 border-cyan-400 shadow-lg">
                     <AvatarImage src={getHolobotImagePath(getUserHolobotByKey(selectedHolobot)?.name || selectedHolobot)} alt={getUserHolobotByKey(selectedHolobot)?.name || selectedHolobot} />
                     <AvatarFallback>{getUserHolobotByKey(selectedHolobot)?.name?.slice(0,2).toUpperCase() || "??"}</AvatarFallback>
                   </Avatar>
-                  <div className="text-center text-base text-holobots-accent mt-1 font-semibold">
-                    {getUserHolobotByKey(selectedHolobot)?.name} (Lv.{getUserHolobotByKey(selectedHolobot)?.level})
+                  <div className="text-center text-xs sm:text-sm md:text-base text-holobots-accent mt-0.5 sm:mt-1 font-semibold">
+                    {getUserHolobotByKey(selectedHolobot)?.name} <span className="hidden sm:inline">(Lv.{getUserHolobotByKey(selectedHolobot)?.level})</span>
                   </div>
                 </div>
               )}
             </div>
 
             {/* VS Component */}
-            <div className="flex flex-col items-center mx-4">
-              <div className="text-holobots-accent font-bold text-xl">VS</div>
-              <div className="text-sm text-gray-400">3 Rounds</div>
+            <div className="flex flex-col items-center mx-2 sm:mx-3 md:mx-4">
+              <div className="text-holobots-accent font-bold text-base sm:text-lg md:text-xl">VS</div>
+              <div className="text-[10px] sm:text-xs md:text-sm text-gray-400">3 Rounds</div>
             </div>
 
             {/* Opponents */}
             <div className="flex-1 flex justify-center">
               <div className="flex flex-col items-center">
-                <div className="flex gap-2 justify-center">
+                <div className="flex gap-1 sm:gap-1.5 md:gap-2 justify-center">
                   {opponentHolobots.map((opponentKey, idx) => (
                     <div key={idx} className="flex flex-col items-center">
-                      <Avatar className="h-12 w-12 border-2 border-red-400">
+                      <Avatar className="h-8 w-8 sm:h-10 sm:w-10 md:h-12 md:w-12 border border-red-400 sm:border-2">
                         <AvatarImage src={getHolobotImagePath(HOLOBOT_STATS[opponentKey].name)} alt={HOLOBOT_STATS[opponentKey].name} />
                         <AvatarFallback>{HOLOBOT_STATS[opponentKey].name.slice(0,2).toUpperCase()}</AvatarFallback>
                       </Avatar>
-                      <div className="text-center text-xs text-red-400 mt-1">Round {idx + 1}</div>
+                      <div className="text-center text-[9px] sm:text-[10px] md:text-xs text-red-400 mt-0.5 sm:mt-1">R{idx + 1}</div>
                     </div>
                   ))}
                 </div>
-                <div className="text-xs text-gray-400 text-center mt-1">Face a new random Holobot each round</div>
+                <div className="text-[9px] sm:text-[10px] md:text-xs text-gray-400 text-center mt-0.5 sm:mt-1 hidden sm:block">Face a new random Holobot each round</div>
               </div>
             </div>
           </div>
 
           {/* Third Row: Payment Options */}
-          <div className="flex flex-col md:flex-row gap-4 w-full border-t border-gray-700 pt-4">
+          <div className="flex flex-col md:flex-row gap-2 sm:gap-3 md:gap-4 w-full border-t border-gray-700 pt-2 sm:pt-3 md:pt-4">
             <div className="flex-1">
-              <p className="text-[#8E9196] mb-2 text-center">Entry fee: {ARENA_TIERS[selectedTier].entryFee} Holos tokens</p>
-              <p className="text-[#8E9196] mb-4 text-center">Your balance: {user?.holosTokens || 0} Holos</p>
+              <p className="text-[#8E9196] mb-1 text-center text-xs sm:text-sm">Entry fee: {ARENA_TIERS[selectedTier].entryFee} Holos</p>
+              <p className="text-[#8E9196] mb-2 sm:mb-3 md:mb-4 text-center text-xs sm:text-sm">Balance: {user?.holosTokens || 0} Holos</p>
             </div>
             
-            <div className="border-t md:border-t-0 md:border-l border-gray-700 md:pl-4 pt-4 md:pt-0 flex-1">
-              <p className="text-[#8E9196] mb-2 text-center">Your Arena Passes: {user?.arena_passes || 0}</p>
+            <div className="border-t md:border-t-0 md:border-l border-gray-700 md:pl-4 pt-2 md:pt-0 flex-1">
+              <p className="text-[#8E9196] mb-1 sm:mb-2 text-center text-xs sm:text-sm">Arena Passes: {user?.arena_passes || 0}</p>
             </div>
           </div>
           
           {/* Payment Buttons Row */}
-          <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 md:gap-4">
             <Button 
               onClick={handlePayWithTokens}
               disabled={!user || user.holosTokens < ARENA_TIERS[selectedTier].entryFee || !selectedHolobot}
-              className="flex-1 bg-holobots-accent hover:bg-holobots-hover text-white py-2"
+              className="flex-1 bg-holobots-accent hover:bg-holobots-hover text-white py-2 text-sm sm:text-base"
             >
-              <Gem className="mr-2 h-4 w-4" />
+              <Gem className="mr-1 sm:mr-2 h-3 w-3 sm:h-4 sm:w-4" />
               Pay Entry Fee
             </Button>
             
             <Button
               onClick={handleUseArenaPass}
               disabled={!user || !user.arena_passes || user.arena_passes <= 0 || !selectedHolobot}
-              className="flex-1 bg-yellow-500 hover:bg-yellow-600 text-white py-2"
+              className="flex-1 bg-yellow-500 hover:bg-yellow-600 text-white py-2 text-sm sm:text-base"
             >
-              <Award className="mr-2 h-4 w-4" />
+              <Award className="mr-1 sm:mr-2 h-3 w-3 sm:h-4 sm:w-4" />
               Use Arena Pass
             </Button>
           </div>
 
           {/* Fourth Row: Tier Selection - Compact Version */}
-          <div className="border-t border-gray-700 pt-4">
-            <h3 className="text-holobots-accent mb-2 text-center font-orbitron">Select Arena Tier</h3>
-            <div className="grid grid-cols-2 gap-2">
+          <div className="border-t border-gray-700 pt-2 sm:pt-3 md:pt-4">
+            <h3 className="text-holobots-accent mb-1 sm:mb-1.5 md:mb-2 text-center font-orbitron text-sm sm:text-base">Select Arena Tier</h3>
+            <div className="grid grid-cols-2 gap-1.5 sm:gap-2">
               {(Object.entries(ARENA_TIERS) as [keyof typeof ARENA_TIERS, typeof ARENA_TIERS[keyof typeof ARENA_TIERS]][]).map(([key, tier]) => (
                 <div 
                   key={key}
                   className={`
-                    flex justify-between items-center p-2 rounded-lg cursor-pointer border
+                    flex justify-between items-center p-1.5 sm:p-2 rounded-lg cursor-pointer border
                     ${selectedTier === key 
                       ? 'bg-holobots-accent bg-opacity-20 border-holobots-accent' 
                       : 'bg-black/40 border-holobots-border hover:border-holobots-accent/50'}
@@ -382,45 +382,45 @@ export const ArenaPrebattleMenu = ({
                   onClick={() => setSelectedTier(key)}
                 >
                   {/* Tier Info */}
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-1 sm:gap-1.5 md:gap-2">
                     <div className={`
-                      p-1.5 rounded-full 
+                      p-1 sm:p-1.5 rounded-full 
                       ${selectedTier === key ? 'bg-holobots-accent text-white' : 'bg-gray-800 text-holobots-accent'}
                     `}>
-                      <Trophy className="h-3.5 w-3.5" />
+                      <Trophy className="h-2.5 w-2.5 sm:h-3 sm:w-3 md:h-3.5 md:w-3.5" />
                     </div>
                     <div>
-                      <h4 className="text-sm font-semibold text-white capitalize">{key}</h4>
-                      <div className="flex items-center gap-1">
-                        <span className="text-xs text-gray-400">Lv.{tier.level}+</span>
-                        <span className="text-xs font-medium text-yellow-400">{tier.entryFee} Holos</span>
+                      <h4 className="text-xs sm:text-sm font-semibold text-white capitalize">{key}</h4>
+                      <div className="flex items-center gap-0.5 sm:gap-1">
+                        <span className="text-[9px] sm:text-[10px] md:text-xs text-gray-400">Lv.{tier.level}+</span>
+                        <span className="text-[9px] sm:text-[10px] md:text-xs font-medium text-yellow-400">{tier.entryFee} Holos</span>
                       </div>
                     </div>
                   </div>
 
                   {/* Tier Rewards - Compact */}
-                  <div className="flex items-center gap-1 text-xs">
+                  <div className="flex items-center gap-0.5 sm:gap-1 text-[9px] sm:text-[10px] md:text-xs">
                     {'holosTokens' in tier.rewards && tier.rewards.holosTokens && tier.rewards.holosTokens > 0 && (
-                      <div className="flex items-center mr-1">
-                        <Gem className="h-3 w-3 text-yellow-400 mr-0.5" />
+                      <div className="flex items-center mr-0.5 sm:mr-1">
+                        <Gem className="h-2 w-2 sm:h-2.5 sm:w-2.5 md:h-3 md:w-3 text-yellow-400 mr-0.5" />
                         <span className="text-yellow-400 font-medium">{tier.rewards.holosTokens}</span>
                       </div>
                     )}
                     {tier.rewards.items.energy_refills > 0 && (
-                    <div className="flex items-center mr-1">
-                      <Star className="h-3 w-3 text-white mr-0.5" /> {/* Assuming Energy Refill is common display */}
+                    <div className="flex items-center mr-0.5 sm:mr-1">
+                      <Star className="h-2 w-2 sm:h-2.5 sm:w-2.5 md:h-3 md:w-3 text-white mr-0.5" /> {/* Assuming Energy Refill is common display */}
                       <span className="text-white">ER x{tier.rewards.items.energy_refills}</span>
                     </div>
                     )}
                     {tier.rewards.items.exp_boosters > 0 && (
-                    <div className="flex items-center mr-1">
-                      <Star className="h-3 w-3 text-blue-400 mr-0.5" /> {/* Assuming EXP Booster is rare display */}
+                    <div className="flex items-center mr-0.5 sm:mr-1">
+                      <Star className="h-2 w-2 sm:h-2.5 sm:w-2.5 md:h-3 md:w-3 text-blue-400 mr-0.5" /> {/* Assuming EXP Booster is rare display */}
                       <span className="text-blue-400">EB x{tier.rewards.items.exp_boosters}</span>
                     </div>
                     )}
                     {tier.rewards.items.rank_skips > 0 && (
                     <div className="flex items-center">
-                      <Star className="h-3 w-3 text-purple-400 mr-0.5" /> {/* Assuming Rank Skip is legendary display */}
+                      <Star className="h-2 w-2 sm:h-2.5 sm:w-2.5 md:h-3 md:w-3 text-purple-400 mr-0.5" /> {/* Assuming Rank Skip is legendary display */}
                       <span className="text-purple-400">RS x{tier.rewards.items.rank_skips}</span>
                     </div>
                     )}

--- a/src/components/arena/BattleArenaView.tsx
+++ b/src/components/arena/BattleArenaView.tsx
@@ -3,17 +3,19 @@
 // Main battle visualization component
 // ============================================================================
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useArenaBattleStore } from '@/stores/arena-battle-store';
 import { FighterDisplay } from './FighterDisplay';
 import { ActionCardHand } from './ActionCardHand';
 import { BattleControls } from './BattleControls';
 import { BattlefieldCenter } from './BattlefieldCenter';
 import { Button } from '@/components/ui/button';
-import { Trophy, Skull, Coins, Zap } from 'lucide-react';
+import { Trophy, Skull, Coins, Zap, RotateCcw } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 export function BattleArenaView() {
+  const [showStats, setShowStats] = useState(false);
+  
   const {
     currentBattle,
     uiState,
@@ -23,6 +25,21 @@ export function BattleArenaView() {
     useSpecialAttack,
     abandonBattle,
   } = useArenaBattleStore();
+
+  // Hide bottom nav during battle
+  useEffect(() => {
+    const nav = document.querySelector('nav[class*="fixed bottom-0"]');
+    if (nav) {
+      (nav as HTMLElement).style.display = 'none';
+    }
+    
+    return () => {
+      const nav = document.querySelector('nav[class*="fixed bottom-0"]');
+      if (nav) {
+        (nav as HTMLElement).style.display = '';
+      }
+    };
+  }, []);
   
   const navigate = useNavigate();
 
@@ -89,177 +106,264 @@ export function BattleArenaView() {
     const rewards = currentBattle.potentialRewards;
     
     return (
-      <div className="flex flex-col items-center justify-center h-screen bg-gradient-to-b from-slate-900 via-purple-900 to-slate-900 p-8">
-        <div className="max-w-2xl w-full bg-slate-800/90 backdrop-blur rounded-2xl p-8 border-2 border-purple-500/50 shadow-2xl">
-          {/* Result Header */}
-          <div className="text-center mb-8">
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-slate-900 via-purple-900 to-slate-900 p-2 sm:p-3 md:p-6 py-3 sm:py-4 md:py-6">
+        <div className="max-w-2xl w-full bg-slate-800/90 backdrop-blur rounded-lg sm:rounded-xl p-2.5 sm:p-3 md:p-5 border-2 border-purple-500/50 shadow-2xl overflow-y-auto max-h-[92vh]">
+          {/* Compact Result Header */}
+          <div className="text-center mb-2 sm:mb-3 md:mb-5">
             {isVictory ? (
               <>
-                <Trophy className="w-24 h-24 mx-auto mb-4 text-yellow-400 animate-bounce" />
-                <h1 className="text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 to-orange-400 mb-2">
-                  {currentBattle.roundsWon === currentBattle.totalRounds ? 'ARENA COMPLETE!' : 'VICTORY!'}
+                <Trophy className="w-8 h-8 sm:w-12 sm:h-12 md:w-16 md:h-16 mx-auto mb-1 sm:mb-2 text-yellow-400" />
+                <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 to-orange-400 mb-0.5 sm:mb-1">
+                  {currentBattle.roundsWon === currentBattle.totalRounds ? 'COMPLETE!' : 'VICTORY!'}
                 </h1>
-                <p className="text-xl text-gray-300">
-                  Rounds Won: {currentBattle.roundsWon}/{currentBattle.totalRounds}
+                <p className="text-xs sm:text-sm text-gray-300">
+                  {currentBattle.roundsWon}/{currentBattle.totalRounds} Rounds Won
                 </p>
-                {currentBattle.roundsWon === currentBattle.totalRounds && (
-                  <p className="text-lg text-green-400 mt-2">
-                    🏆 Perfect Run! All opponents defeated! 🏆
-                  </p>
-                )}
               </>
             ) : (
               <>
-                <Skull className="w-24 h-24 mx-auto mb-4 text-red-400" />
-                <h1 className="text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-red-400 to-orange-400 mb-2">
+                <Skull className="w-8 h-8 sm:w-12 sm:h-12 md:w-16 md:h-16 mx-auto mb-1 sm:mb-2 text-red-400" />
+                <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-red-400 to-orange-400 mb-0.5 sm:mb-1">
                   DEFEAT
                 </h1>
-                <p className="text-xl text-gray-300">
-                  {opponent.name} wins this round...
+                <p className="text-xs sm:text-sm text-gray-300">
+                  {opponent.name} wins
                 </p>
               </>
             )}
           </div>
 
-          {/* Battle Stats */}
-          <div className="grid grid-cols-2 gap-4 mb-6">
-            <div className="bg-blue-900/30 p-4 rounded-lg">
-              <p className="text-sm text-gray-400 mb-1">Your Stats</p>
-              <p className="text-lg font-bold text-white">{player.name}</p>
-              <p className="text-sm text-gray-300">HP: {player.currentHP}/{player.maxHP}</p>
-              <p className="text-sm text-gray-300">Damage Dealt: {player.totalDamageDealt}</p>
-            </div>
-            <div className="bg-red-900/30 p-4 rounded-lg">
-              <p className="text-sm text-gray-400 mb-1">Opponent Stats</p>
-              <p className="text-lg font-bold text-white">{opponent.name}</p>
-              <p className="text-sm text-gray-300">HP: {opponent.currentHP}/{opponent.maxHP}</p>
-              <p className="text-sm text-gray-300">Damage Dealt: {opponent.totalDamageDealt}</p>
-            </div>
-          </div>
+          {/* Flippable Stats/Rewards Card */}
+          <div 
+            className="relative mb-2 sm:mb-3 md:mb-4 cursor-pointer"
+            onClick={() => setShowStats(!showStats)}
+            style={{ 
+              perspective: '1000px',
+              minHeight: showStats ? '200px' : 'auto'
+            }}
+          >
+            <div 
+              className="relative transition-transform duration-500 preserve-3d"
+              style={{
+                transformStyle: 'preserve-3d',
+                transform: showStats ? 'rotateY(180deg)' : 'rotateY(0deg)'
+              }}
+            >
+              {/* Front: Rewards */}
+              <div 
+                className="backface-hidden"
+                style={{
+                  backfaceVisibility: 'hidden',
+                  WebkitBackfaceVisibility: 'hidden'
+                }}
+              >
 
-          {/* Rewards */}
-          {isVictory && rewards && (
-            <div className="bg-gradient-to-r from-purple-900/30 to-blue-900/30 p-6 rounded-lg mb-6">
-              <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
-                <Trophy className="w-6 h-6 text-yellow-400" />
-                Rewards Earned
-              </h2>
-              <div className="grid grid-cols-2 gap-4">
-                {rewards.exp && (
-                  <div className="flex items-center gap-2 bg-blue-500/20 p-3 rounded">
-                    <Zap className="w-5 h-5 text-blue-400" />
-                    <div>
-                      <p className="text-sm text-gray-300">Experience</p>
-                      <p className="text-lg font-bold text-blue-400">+{Math.floor(rewards.exp)} XP</p>
+                {/* Rewards Section */}
+                {isVictory && rewards && (
+                  <div className="bg-gradient-to-r from-purple-900/30 to-blue-900/30 p-2 sm:p-3 md:p-4 rounded-lg">
+                    <div className="flex items-center justify-between mb-1.5 sm:mb-2">
+                      <h2 className="text-sm sm:text-base md:text-lg font-bold text-white flex items-center gap-1">
+                        <Trophy className="w-3 h-3 sm:w-4 sm:h-4 md:w-5 md:h-5 text-yellow-400" />
+                        Rewards
+                      </h2>
+                      <button className="text-[10px] sm:text-xs text-cyan-400 flex items-center gap-1">
+                        <RotateCcw className="w-3 h-3" />
+                        View Stats
+                      </button>
                     </div>
-                  </div>
-                )}
-                {rewards.syncPoints && (
-                  <div className="flex items-center gap-2 bg-purple-500/20 p-3 rounded">
-                    <Zap className="w-5 h-5 text-purple-400" />
-                    <div>
-                      <p className="text-sm text-gray-300">Sync Points</p>
-                      <p className="text-lg font-bold text-purple-400">+{Math.floor(rewards.syncPoints)}</p>
+                    <div className="grid grid-cols-2 gap-1.5 sm:gap-2">
+                      {rewards.exp && (
+                        <div className="flex items-center gap-1 bg-blue-500/20 p-1.5 sm:p-2 rounded">
+                          <Zap className="w-3 h-3 text-blue-400 flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-[9px] sm:text-[10px] text-gray-300">XP</p>
+                            <p className="text-xs sm:text-sm font-bold text-blue-400 truncate">+{Math.floor(rewards.exp)}</p>
+                          </div>
+                        </div>
+                      )}
+                      {rewards.syncPoints && (
+                        <div className="flex items-center gap-1 bg-purple-500/20 p-1.5 sm:p-2 rounded">
+                          <Zap className="w-3 h-3 text-purple-400 flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-[9px] sm:text-[10px] text-gray-300">SP</p>
+                            <p className="text-xs sm:text-sm font-bold text-purple-400 truncate">+{Math.floor(rewards.syncPoints)}</p>
+                          </div>
+                        </div>
+                      )}
+                      {rewards.gachaTickets && rewards.gachaTickets > 0 && (
+                        <div className="flex items-center gap-1 bg-pink-500/20 p-1.5 sm:p-2 rounded">
+                          <Trophy className="w-3 h-3 text-pink-400 flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-[9px] sm:text-[10px] text-gray-300">Gacha</p>
+                            <p className="text-xs sm:text-sm font-bold text-pink-400 truncate">+{rewards.gachaTickets}</p>
+                          </div>
+                        </div>
+                      )}
+                      {rewards.boosterPackTickets && rewards.boosterPackTickets > 0 && (
+                        <div className="flex items-center gap-1 bg-orange-500/20 p-1.5 sm:p-2 rounded">
+                          <Trophy className="w-3 h-3 text-orange-400 flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-[9px] sm:text-[10px] text-gray-300">Booster</p>
+                            <p className="text-xs sm:text-sm font-bold text-orange-400 truncate">+{rewards.boosterPackTickets}</p>
+                          </div>
+                        </div>
+                      )}
+                      {rewards.holos && rewards.holos > 0 && (
+                        <div className="flex items-center gap-1 bg-green-500/20 p-1.5 sm:p-2 rounded">
+                          <Coins className="w-3 h-3 text-green-400 flex-shrink-0" />
+                          <div className="min-w-0">
+                            <p className="text-[9px] sm:text-[10px] text-gray-300">HOLOS</p>
+                            <p className="text-xs sm:text-sm font-bold text-green-400 truncate">+{rewards.holos}</p>
+                          </div>
+                        </div>
+                      )}
+                      {rewards.blueprintRewards && rewards.blueprintRewards.length > 0 && (
+                        <div className="col-span-2">
+                          <p className="text-[9px] sm:text-[10px] text-gray-400 mb-1">Blueprints:</p>
+                          <div className="space-y-1">
+                            {rewards.blueprintRewards.map((blueprint, index) => (
+                              <div key={index} className="flex items-center gap-1 bg-cyan-500/20 p-1.5 rounded">
+                                <Trophy className="w-3 h-3 text-cyan-400 flex-shrink-0" />
+                                <p className="text-xs font-bold text-cyan-400 truncate">
+                                  +{blueprint.amount} {blueprint.holobotKey.toUpperCase()}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
-                  </div>
-                )}
-                {rewards.gachaTickets && rewards.gachaTickets > 0 && (
-                  <div className="flex items-center gap-2 bg-pink-500/20 p-3 rounded">
-                    <Trophy className="w-5 h-5 text-pink-400" />
-                    <div>
-                      <p className="text-sm text-gray-300">Gacha Tickets</p>
-                      <p className="text-lg font-bold text-pink-400">+{rewards.gachaTickets}</p>
-                    </div>
-                  </div>
-                )}
-                {rewards.boosterPackTickets && rewards.boosterPackTickets > 0 && (
-                  <div className="flex items-center gap-2 bg-orange-500/20 p-3 rounded">
-                    <Trophy className="w-5 h-5 text-orange-400" />
-                    <div>
-                      <p className="text-sm text-gray-300">Booster Packs</p>
-                      <p className="text-lg font-bold text-orange-400">+{rewards.boosterPackTickets}</p>
-                    </div>
-                  </div>
-                )}
-                {rewards.holos && rewards.holos > 0 && (
-                  <div className="flex items-center gap-2 bg-green-500/20 p-3 rounded">
-                    <Coins className="w-5 h-5 text-green-400" />
-                    <div>
-                      <p className="text-sm text-gray-300">HOLOS (Tier 3 Only!)</p>
-                      <p className="text-lg font-bold text-green-400">+{rewards.holos}</p>
-                    </div>
-                  </div>
-                )}
-                {rewards.blueprintRewards && rewards.blueprintRewards.length > 0 && (
-                  <div className="col-span-2 space-y-2">
-                    <p className="text-sm text-gray-300 font-semibold mb-2">Blueprint Pieces</p>
-                    {rewards.blueprintRewards.map((blueprint, index) => (
-                      <div key={index} className="flex items-center gap-2 bg-cyan-500/20 p-3 rounded">
-                        <Trophy className="w-5 h-5 text-cyan-400" />
-                        <div>
-                          <p className="text-lg font-bold text-cyan-400">
-                            +{blueprint.amount} {blueprint.holobotKey.toUpperCase()} pieces
-                          </p>
+                    
+                    {/* Bonus Rewards - Compact */}
+                    {(rewards.perfectDefenseBonus || rewards.comboBonus || rewards.speedBonus) && (
+                      <div className="mt-1.5 pt-1.5 border-t border-gray-700">
+                        <p className="text-[9px] text-gray-400 mb-0.5">Bonus:</p>
+                        <div className="flex flex-wrap gap-1">
+                          {rewards.comboBonus && (
+                            <span className="bg-orange-500/20 text-orange-300 px-1.5 py-0.5 rounded text-[9px]">
+                              ⚡ +{rewards.comboBonus}
+                            </span>
+                          )}
+                          {rewards.perfectDefenseBonus && (
+                            <span className="bg-blue-500/20 text-blue-300 px-1.5 py-0.5 rounded text-[9px]">
+                              🛡️ +{rewards.perfectDefenseBonus}
+                            </span>
+                          )}
+                          {rewards.speedBonus && (
+                            <span className="bg-cyan-500/20 text-cyan-300 px-1.5 py-0.5 rounded text-[9px]">
+                              ⏱️ +{rewards.speedBonus}
+                            </span>
+                          )}
                         </div>
                       </div>
-                    ))}
+                    )}
                   </div>
                 )}
               </div>
-              
-              {/* Bonus Rewards */}
-              {(rewards.perfectDefenseBonus || rewards.comboBonus || rewards.speedBonus) && (
-                <div className="mt-4 pt-4 border-t border-gray-700">
-                  <p className="text-sm text-gray-400 mb-2">Bonus Rewards:</p>
-                  <div className="flex flex-wrap gap-2">
-                    {rewards.perfectDefenseBonus && (
-                      <span className="bg-blue-500/20 text-blue-300 px-3 py-1 rounded-full text-sm">
-                        🛡️ Perfect Defense: +{rewards.perfectDefenseBonus} XP
-                      </span>
-                    )}
-                    {rewards.comboBonus && (
-                      <span className="bg-orange-500/20 text-orange-300 px-3 py-1 rounded-full text-sm">
-                        ⚡ Combos: +{rewards.comboBonus} XP
-                      </span>
-                    )}
-                    {rewards.speedBonus && (
-                      <span className="bg-cyan-500/20 text-cyan-300 px-3 py-1 rounded-full text-sm">
-                        ⏱️ Speed: +{rewards.speedBonus} XP
-                      </span>
-                    )}
-                  </div>
-                </div>
-              )}
-              
-              {rewards.eloChange && (
-                <div className="mt-4 pt-4 border-t border-gray-700">
-                  <p className="text-sm text-gray-400">Ranked ELO</p>
-                  <p className={`text-lg font-bold ${rewards.eloChange > 0 ? 'text-green-400' : 'text-red-400'}`}>
-                    {rewards.eloChange > 0 ? '+' : ''}{rewards.eloChange}
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
 
-          {/* Actions */}
-          <div className="flex gap-4">
+              {/* Back: Battle Stats */}
+              <div 
+                className="absolute inset-0 backface-hidden"
+                style={{
+                  backfaceVisibility: 'hidden',
+                  WebkitBackfaceVisibility: 'hidden',
+                  transform: 'rotateY(180deg)'
+                }}
+              >
+                <div className="bg-gradient-to-r from-blue-900/30 to-red-900/30 p-2 sm:p-3 md:p-4 rounded-lg h-full">
+                  <div className="flex items-center justify-between mb-1.5 sm:mb-2">
+                    <h2 className="text-sm sm:text-base md:text-lg font-bold text-white flex items-center gap-1">
+                      📊 Battle Stats
+                    </h2>
+                    <button className="text-[10px] sm:text-xs text-cyan-400 flex items-center gap-1">
+                      <RotateCcw className="w-3 h-3" />
+                      View Rewards
+                    </button>
+                  </div>
+
+                  {/* All 3 Rounds Summary */}
+                  <div className="space-y-1">
+                    {Array.from({ length: currentBattle.totalRounds }).map((_, index) => {
+                      const roundNum = index + 1;
+                      const opponentForRound = currentBattle.opponentLineup[index];
+                      const isCurrentRound = roundNum === currentBattle.currentRound;
+                      const wasWon = roundNum < currentBattle.currentRound 
+                        ? (currentBattle.roundsWon >= roundNum) 
+                        : (roundNum === currentBattle.currentRound && currentBattle.status === 'completed' && currentBattle.roundsWon >= roundNum);
+                      
+                      return (
+                        <div 
+                          key={roundNum} 
+                          className={`p-1.5 rounded ${
+                            isCurrentRound 
+                              ? 'bg-yellow-900/30 border border-yellow-500/50' 
+                              : wasWon 
+                                ? 'bg-green-900/20 border border-green-500/30' 
+                                : 'bg-gray-900/20 border border-gray-700/30'
+                          }`}
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2">
+                              <span className="text-[10px] text-gray-400">R{roundNum}:</span>
+                              <span className="text-xs font-bold text-white">{player.name}</span>
+                              <span className="text-[10px] text-gray-500">vs</span>
+                              <span className="text-xs font-bold text-red-400">{opponentForRound?.toUpperCase() || 'TBD'}</span>
+                            </div>
+                            <div>
+                              {isCurrentRound && currentBattle.status === 'active' && (
+                                <span className="text-[9px] text-yellow-400">▶ Active</span>
+                              )}
+                              {wasWon && (
+                                <span className="text-[9px] text-green-400">✓ Won</span>
+                              )}
+                              {!isCurrentRound && !wasWon && roundNum < currentBattle.currentRound && (
+                                <span className="text-[9px] text-red-400">✗ Lost</span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Current Round Details */}
+                  {currentBattle.status === 'active' && (
+                    <div className="mt-2 bg-black/20 p-1.5 rounded">
+                      <p className="text-[9px] text-gray-400 mb-0.5">Current Stats:</p>
+                      <div className="grid grid-cols-2 gap-2 text-[9px]">
+                        <div>
+                          <span className="text-blue-400">{player.name}:</span>
+                          <span className="text-white ml-1">{player.currentHP}/{player.maxHP} HP</span>
+                        </div>
+                        <div>
+                          <span className="text-red-400">{opponent.name}:</span>
+                          <span className="text-white ml-1">{opponent.currentHP}/{opponent.maxHP} HP</span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Action Buttons - Compact */}
+          <div className="flex gap-2">
             <Button
               onClick={() => {
                 abandonBattle();
                 navigate('/app');
               }}
-              className="flex-1 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white py-4 text-lg font-bold"
+              className="flex-1 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white py-2 sm:py-2.5 text-xs sm:text-sm font-bold"
             >
               Return to Arena
             </Button>
             <Button
               onClick={() => {
                 abandonBattle();
-                // Restart battle with same configuration
                 window.location.reload();
               }}
-              className="flex-1 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white py-4 text-lg font-bold"
+              className="flex-1 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white py-2 sm:py-2.5 text-xs sm:text-sm font-bold"
             >
               Battle Again
             </Button>
@@ -270,19 +374,19 @@ export function BattleArenaView() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-gradient-to-b from-slate-900 via-purple-900 to-slate-900 overflow-hidden">
-      {/* Arena Header */}
-      <div className="p-4 text-center border-b border-purple-500/30">
-        <h1 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-purple-400">
-          HOLOBOTS ARENA V2
+    <div className="flex flex-col h-screen bg-gradient-to-b from-slate-900 via-purple-900 to-slate-900 overflow-hidden pb-0">
+      {/* Arena Header - Ultra Compact */}
+      <div className="p-1 sm:p-2 text-center border-b border-purple-500/30">
+        <h1 className="text-sm sm:text-lg md:text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-purple-400">
+          ARENA V2
         </h1>
-        <p className="text-sm text-gray-400 mt-1">
-          Round {currentBattle.currentRound}/{currentBattle.totalRounds} • Wins: {currentBattle.roundsWon}
+        <p className="text-[9px] sm:text-[10px] text-gray-400">
+          R{currentBattle.currentRound}/{currentBattle.totalRounds} • W:{currentBattle.roundsWon}
         </p>
       </div>
 
-      {/* Opponent (Top) */}
-      <div className="p-4">
+      {/* Opponent (Top) - Minimal Padding */}
+      <div className="p-1 sm:p-2">
         <FighterDisplay
           fighter={opponent}
           position="top"
@@ -290,13 +394,13 @@ export function BattleArenaView() {
         />
       </div>
 
-      {/* Battlefield Center */}
-      <div className="flex-1 relative overflow-hidden">
+      {/* Battlefield Center - Minimal Height */}
+      <div className="relative overflow-hidden" style={{ minHeight: '80px', maxHeight: '120px' }}>
         <BattlefieldCenter battle={currentBattle} />
       </div>
 
-      {/* Player (Bottom) */}
-      <div className="p-4 space-y-4">
+      {/* Player (Bottom) - Minimal Padding */}
+      <div className="p-1 sm:p-2 space-y-1 sm:space-y-1.5">
         <FighterDisplay
           fighter={player}
           position="bottom"

--- a/src/components/arena/BattleControls.tsx
+++ b/src/components/arena/BattleControls.tsx
@@ -19,14 +19,14 @@ export function BattleControls({
   canUseSpecial,
 }: BattleControlsProps) {
   return (
-    <div className="flex gap-3">
+    <div className="flex gap-1.5 sm:gap-2 md:gap-3">
       {/* Defense Mode */}
       <button
         onClick={onDefenseMode}
-        className="flex-1 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-bold py-3 px-4 rounded-lg transition-all duration-200 hover:scale-105 active:scale-95 flex items-center justify-center gap-2"
+        className="flex-1 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-bold py-2 sm:py-2.5 md:py-3 px-2 sm:px-3 md:px-4 rounded-lg transition-all duration-200 hover:scale-105 active:scale-95 flex items-center justify-center gap-1 sm:gap-1.5 md:gap-2"
       >
-        <span className="text-xl">🛡️</span>
-        <span>DEFEND</span>
+        <span className="text-base sm:text-lg md:text-xl">🛡️</span>
+        <span className="text-xs sm:text-sm md:text-base">DEFEND</span>
       </button>
 
       {/* Hack Ability */}
@@ -37,10 +37,10 @@ export function BattleControls({
           hackUsed
             ? 'bg-gray-600 cursor-not-allowed opacity-50'
             : 'bg-cyan-600 hover:bg-cyan-700 active:bg-cyan-800 hover:scale-105 active:scale-95'
-        } text-white font-bold py-3 px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-2`}
+        } text-white font-bold py-2 sm:py-2.5 md:py-3 px-2 sm:px-3 md:px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-1 sm:gap-1.5 md:gap-2`}
       >
-        <span className="text-xl">⚙️</span>
-        <span>{hackUsed ? 'USED' : 'HACK'}</span>
+        <span className="text-base sm:text-lg md:text-xl">⚙️</span>
+        <span className="text-xs sm:text-sm md:text-base">{hackUsed ? 'USED' : 'HACK'}</span>
       </button>
 
       {/* Special Attack */}
@@ -51,10 +51,10 @@ export function BattleControls({
           canUseSpecial
             ? 'bg-purple-600 hover:bg-purple-700 active:bg-purple-800 hover:scale-105 active:scale-95 animate-pulse'
             : 'bg-gray-600 cursor-not-allowed opacity-50'
-        } text-white font-bold py-3 px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-2`}
+        } text-white font-bold py-2 sm:py-2.5 md:py-3 px-2 sm:px-3 md:px-4 rounded-lg transition-all duration-200 flex items-center justify-center gap-1 sm:gap-1.5 md:gap-2`}
       >
-        <span className="text-xl">💥</span>
-        <span>FINISHER</span>
+        <span className="text-base sm:text-lg md:text-xl">💥</span>
+        <span className="text-xs sm:text-sm md:text-base">FINISHER</span>
       </button>
     </div>
   );

--- a/src/components/arena/BattlefieldCenter.tsx
+++ b/src/components/arena/BattlefieldCenter.tsx
@@ -13,62 +13,55 @@ export function BattlefieldCenter({ battle }: BattlefieldCenterProps) {
   const recentActions = battle.actionHistory.slice(-5);
 
   return (
-    <div className="relative w-full h-full flex flex-col items-center justify-center">
-      {/* Background Arena */}
-      <div className="absolute inset-0 bg-gradient-to-b from-purple-900/20 to-slate-900/40 flex items-center justify-center">
-        <div className="text-9xl font-bold text-purple-500/10">VS</div>
+    <div className="relative w-full h-full flex flex-col">
+      {/* Background Arena - Smaller */}
+      <div className="absolute inset-0 bg-gradient-to-b from-purple-900/20 to-slate-900/40 flex items-center justify-center opacity-30">
+        <div className="text-5xl sm:text-7xl md:text-9xl font-bold text-purple-500/20">VS</div>
       </div>
 
-      {/* Battle Status */}
-      <div className="relative z-10 text-center space-y-4">
-        {/* Turn Counter */}
-        <div className="bg-black/50 backdrop-blur rounded-lg px-6 py-3 inline-block">
-          <p className="text-sm text-gray-400 uppercase tracking-wide">Turn</p>
-          <p className="text-4xl font-bold text-white">{battle.turnNumber}</p>
-        </div>
-
-        {/* Current Actor Indicator */}
-        <div className="bg-yellow-500/20 backdrop-blur border border-yellow-400 rounded-lg px-4 py-2 inline-block">
-          <p className="text-sm text-yellow-400 font-bold">
-            {battle.currentActorId === battle.player.holobotId
-              ? '▼ YOUR TURN'
-              : '▲ OPPONENT\'S TURN'}
-          </p>
-        </div>
-
-        {/* Counter Window Indicator */}
-        {battle.counterWindowOpen && (
-          <div className="bg-cyan-500/30 backdrop-blur border border-cyan-400 rounded-lg px-4 py-2 inline-block animate-pulse">
-            <p className="text-sm text-cyan-300 font-bold">
-              ⚡ COUNTER WINDOW OPEN!
+      {/* Counter Window Indicator - Top if active */}
+      {battle.counterWindowOpen && (
+        <div className="relative z-10 flex justify-center pt-1 sm:pt-2">
+          <div className="bg-cyan-500/30 backdrop-blur border border-cyan-400 rounded-lg px-2 py-1 inline-block animate-pulse">
+            <p className="text-[10px] sm:text-xs text-cyan-300 font-bold">
+              ⚡ COUNTER WINDOW!
             </p>
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
-      {/* Battle Log (Recent Actions) */}
+      {/* Combined Battle Log and Turn Counter - Side by side at top */}
       {recentActions.length > 0 && (
-        <div className="absolute bottom-4 left-4 right-4 bg-black/70 backdrop-blur rounded-lg p-3 max-h-32 overflow-y-auto">
-          <p className="text-xs text-gray-400 uppercase mb-2">Battle Log</p>
-          <div className="space-y-1">
-            {recentActions.map((action) => (
-              <div key={action.id} className="text-xs text-gray-300">
-                <span className={action.actorRole === 'player' ? 'text-blue-400' : 'text-red-400'}>
-                  {action.actorRole === 'player' ? 'You' : 'Opponent'}
-                </span>
-                {' '}
-                <span className="text-white">{action.card.name}</span>
-                {action.damageDealt > 0 && (
-                  <span className="text-yellow-400"> • {action.actualDamage} DMG</span>
-                )}
-                {action.perfectDefense && (
-                  <span className="text-cyan-400"> • PERFECT!</span>
-                )}
-                {action.triggeredCombo && (
-                  <span className="text-orange-400"> • COMBO!</span>
-                )}
-              </div>
-            ))}
+        <div className="relative z-10 mt-1 sm:mt-2 mx-2 flex gap-2">
+          {/* Battle Log - Left side, takes most space */}
+          <div className="flex-1 bg-black/70 backdrop-blur rounded-lg p-1.5 sm:p-2 max-h-24 sm:max-h-28 overflow-y-auto">
+            <p className="text-[9px] sm:text-[10px] text-gray-400 uppercase mb-0.5">Log</p>
+            <div className="space-y-0.5">
+              {recentActions.map((action) => (
+                <div key={action.id} className="text-[9px] sm:text-[10px] text-gray-300">
+                  <span className={action.actorRole === 'player' ? 'text-blue-400' : 'text-red-400'}>
+                    {action.actorRole === 'player' ? 'You' : 'Opp'}
+                  </span>
+                  {' '}
+                  <span className="text-white">{action.card.name}</span>
+                  {action.damageDealt > 0 && (
+                    <span className="text-yellow-400"> • {action.actualDamage}</span>
+                  )}
+                  {action.perfectDefense && (
+                    <span className="text-cyan-400"> • ✓</span>
+                  )}
+                  {action.triggeredCombo && (
+                    <span className="text-orange-400"> • C</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Turn Counter - Right side, compact */}
+          <div className="bg-black/70 backdrop-blur rounded-lg p-2 sm:p-3 flex flex-col items-center justify-center min-w-[60px] sm:min-w-[70px]">
+            <p className="text-[8px] sm:text-[9px] text-gray-400 uppercase">Turn</p>
+            <p className="text-xl sm:text-2xl md:text-3xl font-bold text-white">{battle.turnNumber}</p>
           </div>
         </div>
       )}

--- a/src/components/arena/FighterDisplay.tsx
+++ b/src/components/arena/FighterDisplay.tsx
@@ -1,10 +1,12 @@
 // ============================================================================
 // Fighter Display
-// Shows fighter status, HP, stamina, special meter
+// Shows fighter status, HP, stamina, special meter, and TCG card
 // ============================================================================
 
 import type { ArenaFighter } from '@/types/arena';
 import { getStaminaState } from '@/types/arena';
+import { HolobotCard } from '@/components/HolobotCard';
+import type { HolobotStats } from '@/types/holobot';
 
 interface FighterDisplayProps {
   fighter: ArenaFighter;
@@ -27,17 +29,39 @@ export function FighterDisplay({ fighter, position, isActive }: FighterDisplayPr
 
   const hpBarColor = hpPercent > 60 ? 'bg-green-500' : hpPercent > 30 ? 'bg-yellow-500' : 'bg-red-500';
 
+  // Convert ArenaFighter to HolobotStats for TCG card
+  const holobotStats: HolobotStats = {
+    name: fighter.name.toUpperCase(),
+    level: fighter.level,
+    maxHealth: fighter.maxHP,
+    attack: fighter.attack,
+    defense: fighter.defense,
+    speed: fighter.speed,
+    specialMove: fighter.specialMove || fighter.archetype.toUpperCase(),
+    abilityDescription: fighter.abilityDescription || `${fighter.archetype} archetype fighter with ${fighter.intelligence} intelligence`,
+  };
+
   return (
     <div
       className={`
-        relative flex items-center gap-4 p-4 rounded-lg
+        relative flex items-center gap-2 sm:gap-3 md:gap-4 p-2 sm:p-3 md:p-4 rounded-lg
         ${isActive ? 'ring-2 ring-yellow-400 shadow-lg shadow-yellow-400/50 animate-pulse-subtle' : ''}
         ${position === 'top' ? 'flex-row bg-red-900/20 backdrop-blur' : 'flex-row-reverse bg-blue-900/20 backdrop-blur'}
       `}
     >
+      {/* TCG Card */}
+      <div className="flex-shrink-0 hidden sm:block">
+        <div className="transform scale-50 sm:scale-[0.6] md:scale-75 origin-center">
+          <HolobotCard 
+            stats={holobotStats}
+            variant={position === 'top' ? 'red' : 'blue'}
+          />
+        </div>
+      </div>
+
       {/* Fighter Avatar */}
       <div className="relative">
-        <div className={`w-20 h-20 rounded-full overflow-hidden border-2 bg-slate-800 ${isActive ? 'border-yellow-400' : 'border-gray-600'}`}>
+        <div className={`w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full overflow-hidden border-2 bg-slate-800 ${isActive ? 'border-yellow-400' : 'border-gray-600'}`}>
           <img
             src={fighter.avatar}
             alt={fighter.name}
@@ -49,8 +73,8 @@ export function FighterDisplay({ fighter, position, isActive }: FighterDisplayPr
           />
         </div>
         {/* Stats Badge */}
-        <div className="absolute -bottom-1 -right-1 bg-gradient-to-r from-purple-600 to-blue-600 text-white text-xs px-2 py-0.5 rounded-full">
-          <div className="flex items-center gap-1">
+        <div className="absolute -bottom-1 -right-1 bg-gradient-to-r from-purple-600 to-blue-600 text-white text-[8px] sm:text-[10px] md:text-xs px-1.5 sm:px-2 py-0.5 rounded-full">
+          <div className="flex items-center gap-0.5 sm:gap-1">
             <span title="Attack">⚔️{fighter.attack}</span>
             <span title="Defense">🛡️{fighter.defense}</span>
           </div>
@@ -58,42 +82,42 @@ export function FighterDisplay({ fighter, position, isActive }: FighterDisplayPr
       </div>
 
       {/* Fighter Stats */}
-      <div className="flex-1 space-y-2">
+      <div className="flex-1 space-y-1 sm:space-y-1.5 md:space-y-2">
         {/* Name & Level & HP */}
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold text-white">{fighter.name}</h2>
-            <span className="bg-gradient-to-r from-cyan-500 to-blue-500 text-white text-xs font-bold px-2 py-0.5 rounded-full">
+          <div className="flex items-center gap-1 sm:gap-1.5 md:gap-2">
+            <h2 className="text-sm sm:text-base md:text-xl font-bold text-white">{fighter.name}</h2>
+            <span className="bg-gradient-to-r from-cyan-500 to-blue-500 text-white text-[9px] sm:text-[10px] md:text-xs font-bold px-1.5 sm:px-2 py-0.5 rounded-full">
               Lv.{fighter.level}
             </span>
           </div>
-          <span className="text-sm text-gray-300">
+          <span className="text-[10px] sm:text-xs md:text-sm text-gray-300">
             {fighter.currentHP} / {fighter.maxHP}
           </span>
         </div>
 
         {/* HP Bar */}
-        <div className="w-full bg-gray-700 rounded-full h-4 relative overflow-hidden">
+        <div className="w-full bg-gray-700 rounded-full h-3 sm:h-3.5 md:h-4 relative overflow-hidden">
           <div
-            className={`${hpBarColor} h-4 rounded-full transition-all duration-300`}
+            className={`${hpBarColor} h-full rounded-full transition-all duration-300`}
             style={{ width: `${hpPercent}%` }}
           />
-          <div className="absolute inset-0 flex items-center justify-center text-xs font-bold text-white drop-shadow">
+          <div className="absolute inset-0 flex items-center justify-center text-[9px] sm:text-[10px] md:text-xs font-bold text-white drop-shadow">
             HP
           </div>
         </div>
 
         {/* Stamina & Special Meter */}
-        <div className="flex gap-2">
+        <div className="flex gap-1.5 sm:gap-2">
           {/* Stamina Cards */}
           <div className="flex-1">
-            <div className="flex items-center gap-1 mb-1">
-              <span className="text-xs text-gray-400">Stamina:</span>
-              <span className={`text-xs font-bold ${staminaColors[staminaState]}`}>
-                {fighter.stamina}/{fighter.maxStamina} ({staminaState.toUpperCase()})
+            <div className="flex items-center gap-0.5 sm:gap-1 mb-0.5 sm:mb-1">
+              <span className="text-[9px] sm:text-[10px] md:text-xs text-gray-400">Stamina:</span>
+              <span className={`text-[9px] sm:text-[10px] md:text-xs font-bold ${staminaColors[staminaState]}`}>
+                {fighter.stamina}/{fighter.maxStamina}
               </span>
             </div>
-            <div className="flex gap-1">
+            <div className="flex gap-0.5 sm:gap-1">
               {Array.from({ length: fighter.maxStamina }).map((_, i) => (
                 <div
                   key={i}
@@ -107,13 +131,13 @@ export function FighterDisplay({ fighter, position, isActive }: FighterDisplayPr
 
           {/* Special Meter */}
           <div className="flex-1">
-            <div className="flex items-center justify-between mb-1">
-              <span className="text-xs text-gray-400">Special:</span>
-              <span className="text-xs font-bold text-cyan-400">{specialPercent}%</span>
+            <div className="flex items-center justify-between mb-0.5 sm:mb-1">
+              <span className="text-[9px] sm:text-[10px] md:text-xs text-gray-400">Special:</span>
+              <span className="text-[9px] sm:text-[10px] md:text-xs font-bold text-cyan-400">{specialPercent}%</span>
             </div>
-            <div className="w-full bg-gray-700 rounded-full h-2 relative overflow-hidden">
+            <div className="w-full bg-gray-700 rounded-full h-1.5 sm:h-2 relative overflow-hidden">
               <div
-                className="bg-gradient-to-r from-cyan-500 to-purple-500 h-2 rounded-full transition-all duration-300"
+                className="bg-gradient-to-r from-cyan-500 to-purple-500 h-full rounded-full transition-all duration-300"
                 style={{ width: `${specialPercent}%` }}
               />
               {specialPercent >= 100 && (
@@ -126,13 +150,13 @@ export function FighterDisplay({ fighter, position, isActive }: FighterDisplayPr
 
       {/* Status Indicators */}
       {fighter.isInDefenseMode && (
-        <div className="absolute top-2 right-2 bg-blue-500 text-white text-xs px-2 py-1 rounded-full animate-pulse">
+        <div className="absolute top-1 sm:top-2 right-1 sm:right-2 bg-blue-500 text-white text-[9px] sm:text-[10px] md:text-xs px-1.5 sm:px-2 py-0.5 sm:py-1 rounded-full animate-pulse">
           🛡️ DEFENSE
         </div>
       )}
 
       {fighter.comboCounter > 0 && (
-        <div className="absolute top-2 right-2 bg-orange-500 text-white text-xs px-2 py-1 rounded-full font-bold">
+        <div className="absolute top-1 sm:top-2 right-1 sm:right-2 bg-orange-500 text-white text-[9px] sm:text-[10px] md:text-xs px-1.5 sm:px-2 py-0.5 sm:py-1 rounded-full font-bold">
           {fighter.comboCounter}x COMBO
         </div>
       )}

--- a/src/lib/arena/card-generator.ts
+++ b/src/lib/arena/card-generator.ts
@@ -11,6 +11,8 @@ import type {
   CardGenerationConfig,
 } from '@/types/arena';
 
+import { generateUUID } from '@/utils/uuid';
+
 // Card templates would normally come from Supabase
 // For now, we'll define them here as a fallback
 
@@ -512,7 +514,7 @@ export class CardPoolGenerator {
     effects?: any[];
   }): ActionCard {
     return {
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       templateId: params.name.toLowerCase().replace(/\s+/g, '_'),
       name: params.name,
       type: params.type,

--- a/src/lib/arena/combat-engine.ts
+++ b/src/lib/arena/combat-engine.ts
@@ -24,6 +24,8 @@ import {
   TEMPO_RESET_DELAY_MS,
 } from '@/types/arena';
 
+import { generateUUID } from '@/utils/uuid';
+
 // ============================================================================
 // Combat Engine Class
 // ============================================================================
@@ -159,7 +161,7 @@ export class ArenaCombatEngine {
         const finisherCard = cardPool.finisherCards[0];
         return {
           ...finisherCard,
-          id: crypto.randomUUID(),
+          id: generateUUID(),
         };
       }
     }
@@ -173,7 +175,7 @@ export class ArenaCombatEngine {
     // Create a new instance with unique ID
     return {
       ...baseCard,
-      id: crypto.randomUUID(), // Give it a new unique ID
+      id: generateUUID(), // Give it a new unique ID
     };
   }
   
@@ -202,7 +204,7 @@ export class ArenaCombatEngine {
     
     // Create battle action
     const action: BattleAction = {
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       battleId: state.battleId,
       turnNumber: state.turnNumber,
       actionOrder: state.actionHistory.filter(a => a.turnNumber === state.turnNumber).length,
@@ -635,7 +637,7 @@ export class ArenaCombatEngine {
         case 'status':
           // Apply status effect
           const statusEffect: StatusEffect = {
-            id: crypto.randomUUID(),
+            id: generateUUID(),
             type: 'damage_over_time', // default, would need more logic here
             value: effect.value,
             duration: effect.duration || 1,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -174,6 +174,10 @@ const ArenaV2Wrapper = () => {
         speed: finalSpeed,
         intelligence: finalIntelligence,
         
+        // TCG Card Display Fields
+        specialMove: userHolobotStats?.specialMove || 'UNKNOWN',
+        abilityDescription: userHolobotStats?.abilityDescription || 'No ability description available.',
+        
         stamina: 6,
         maxStamina: 7,
         specialMeter: 0,
@@ -231,6 +235,10 @@ const ArenaV2Wrapper = () => {
         defense: opponentDefense,
         speed: opponentSpeed,
         intelligence: opponentIntelligence,
+        
+        // TCG Card Display Fields
+        specialMove: opponentBaseStats?.specialMove || 'UNKNOWN',
+        abilityDescription: opponentBaseStats?.abilityDescription || 'No ability description available.',
       };
 
       const config: ArenaBattleConfig = {
@@ -274,7 +282,7 @@ const ArenaV2Wrapper = () => {
   // Show prebattle menu before battle
   if (showPrebattleMenu || !currentBattle) {
     return (
-      <div className="px-4 py-5">
+      <div className="px-2 py-2 sm:px-3 sm:py-3 md:px-4 md:py-5">
         <ArenaPrebattleMenu 
           onHolobotSelect={handleHolobotSelect}
           onEntryFeeMethod={handleEntryFeeMethod}

--- a/src/stores/arena-battle-store.ts
+++ b/src/stores/arena-battle-store.ts
@@ -16,6 +16,7 @@ import type {
 import { ArenaCombatEngine } from '@/lib/arena/combat-engine';
 import { ArenaAI } from '@/lib/arena/ai-controller';
 import { CardPoolGenerator } from '@/lib/arena/card-generator';
+import { generateUUID } from '@/utils/uuid';
 
 // ============================================================================
 // Store Interface
@@ -626,7 +627,7 @@ export const useArenaBattleStore = create<ArenaBattleStore>((set, get) => ({
       const finisherCard = battle.playerCardPool.finisherCards[0];
       const newFinisher = {
         ...finisherCard,
-        id: crypto.randomUUID(),
+        id: generateUUID(),
       };
       
       // Add finisher to hand

--- a/src/types/arena.ts
+++ b/src/types/arena.ts
@@ -44,6 +44,10 @@ export interface ArenaFighter {
   speed: number;
   intelligence: number;
   
+  // Optional TCG Card Display Fields
+  specialMove?: string;
+  abilityDescription?: string;
+  
   // Arena-Specific State
   stamina: number; // current hand size (number of cards)
   maxStamina: number; // maximum hand size

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,16 @@
+/**
+ * Generate a UUID with fallback for environments that don't support crypto.randomUUID
+ */
+export function generateUUID(): string {
+  // Check if crypto.randomUUID is available (modern browsers)
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  
+  // Fallback: Generate UUID v4 manually
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
- Add responsive sizing for all Arena V2 components (cards, stats, rewards)
- Optimize action cards: 80px mobile → 112px desktop
- Compress battle screen: reduce padding/spacing by 60-70%
- Hide bottom navigation during active battles to prevent accidental exits
- Create flippable rewards/stats card to save space
- Move turn counter next to battle log (side-by-side layout)
- Show all 3 rounds in stats view with win/loss indicators
- Add UUID utility with fallback for crypto.randomUUID browser compatibility
- Ultra-compact rewards screen: no scrolling needed on mobile
- Optimize TCG cards in FighterDisplay (hidden on mobile, smaller on tablet)
- Compress BattlefieldCenter: fixed 80-120px height vs flex-1
- Remove 'YOUR TURN' indicator to save space
- All text, icons, and spacing responsive across mobile/tablet/desktop

Result: Complete Arena V2 experience fits on mobile without scrolling